### PR TITLE
Fix NullPointerException when loading properties

### DIFF
--- a/CodeChallenging/src/main/java/code/util/UtilMethods.java
+++ b/CodeChallenging/src/main/java/code/util/UtilMethods.java
@@ -98,15 +98,18 @@ public class UtilMethods {
 	 */
 	public static String getPropertiesFile(String key) throws IOException {
 
-		ClassLoader loader = Thread.currentThread().getContextClassLoader();
-		Properties properties = new Properties();
-		try (InputStream resourceStream = loader.getResourceAsStream(propertyFileName)) {
-			properties.load(resourceStream);
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
+                ClassLoader loader = Thread.currentThread().getContextClassLoader();
+                Properties properties = new Properties();
+                try (InputStream resourceStream = loader.getResourceAsStream(propertyFileName)) {
+                        if (resourceStream == null) {
+                                throw new IOException("Unable to locate " + propertyFileName);
+                        }
+                        properties.load(resourceStream);
+                } catch (IOException e) {
+                        e.printStackTrace();
+                }
 
-		return (String) properties.get(key);
+                return (String) properties.get(key);
 	}
 
 }


### PR DESCRIPTION
## Summary
- improve properties loader to throw an informative error when the properties file can't be found

## Testing
- `javac CodeChallenging/src/main/java/code/util/UtilMethods.java` *(fails: package org.apache.log4j does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6847c998f8208321ab266ab645c5074b